### PR TITLE
Handle missing collectors when exporting CSV

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,20 @@ class SubstackAnalyticsApp:
         collector = SubstackDataCollector(publication_name, self.db_path)
         self.collectors[publication_name] = collector
         return collector
+
+    def get_collector(self, publication_name):
+        """Get an existing collector or create one if data exists."""
+        collector = self.collectors.get(publication_name)
+        if collector:
+            return collector
+
+        publication_data = self.get_publication_data(publication_name)
+        if not publication_data:
+            return None
+
+        collector = SubstackDataCollector(publication_name, self.db_path)
+        self.collectors[publication_name] = collector
+        return collector
     
     def get_publications(self):
         """Get list of tracked publications."""
@@ -170,11 +184,13 @@ def api_export(publication_name):
 def api_export_csv(publication_name):
     """Export data as CSV."""
     try:
-        if publication_name in analytics_app.collectors:
-            filename = f"{publication_name}_analytics_{datetime.now().strftime('%Y%m%d')}"
-            analytics_app.collectors[publication_name].export_to_csv(filename)
-            return send_file(f"{filename}_posts.csv", as_attachment=True)
-        return jsonify({'error': 'Publication not found'}), 404
+        collector = analytics_app.get_collector(publication_name)
+        if not collector:
+            return jsonify({'error': 'Publication not found'}), 404
+
+        filename = f"{publication_name}_analytics_{datetime.now().strftime('%Y%m%d')}"
+        collector.export_to_csv(filename)
+        return send_file(f"{filename}_posts.csv", as_attachment=True)
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 


### PR DESCRIPTION
## Summary
- add a helper on `SubstackAnalyticsApp` to recreate collectors from stored publication data
- use the helper in the CSV export route so previously scraped publications can export after a restart

## Testing
- python - <<'PY'
from main import app

with app.test_client() as client:
    response = client.get('/api/export/Cash%20%26%20Cache%20%7C%20Ashwin%20Francis%20%7C%20Substack/csv')
    assert response.status_code == 200
PY

------
https://chatgpt.com/codex/tasks/task_e_68de9626032c832b94cd54d6a5609e7e