### PR TITLE
Filter CSV export by publication

### DIFF
--- a/enhanced_collector.py
+++ b/enhanced_collector.py
@@ -542,16 +542,36 @@ class SubstackDataCollector:
             filename = f"{self.publication_name}_analytics_{datetime.now().strftime('%Y%m%d')}"
         
         conn = sqlite3.connect(self.db_path)
-        
-        # Export posts
-        posts_df = pd.read_sql_query("SELECT * FROM posts", conn)
-        posts_df.to_csv(f"{filename}_posts.csv", index=False)
-        
-        # Export publication data
-        pub_df = pd.read_sql_query("SELECT * FROM publication", conn)
-        pub_df.to_csv(f"{filename}_publication.csv", index=False)
-        
-        conn.close()
+
+        try:
+            # Export posts filtered by publication URL
+            posts_query = "SELECT * FROM posts WHERE url LIKE ?"
+            posts_params = (f"{self.base_url}/%",)
+            posts_df = pd.read_sql_query(posts_query, conn, params=posts_params)
+            posts_df.to_csv(f"{filename}_posts.csv", index=False)
+
+            # Determine the canonical publication name stored in the database
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM publication WHERE url = ?",
+                (self.base_url,),
+            )
+            row = cursor.fetchone()
+            publication_name = row[0] if row and row[0] else self.publication_name
+
+            # Export publication data filtered to the single publication name
+            pub_query = "SELECT * FROM publication WHERE name = ?"
+            pub_df = pd.read_sql_query(pub_query, conn, params=(publication_name,))
+
+            # Fallback to URL filtering if no row matches the resolved name
+            if pub_df.empty:
+                pub_query = "SELECT * FROM publication WHERE url = ?"
+                pub_df = pd.read_sql_query(pub_query, conn, params=(self.base_url,))
+
+            pub_df.to_csv(f"{filename}_publication.csv", index=False)
+
+        finally:
+            conn.close()
         self.logger.info(f"Data exported to {filename}_*.csv")
     
     def close(self):

--- a/tests/test_export_to_csv.py
+++ b/tests/test_export_to_csv.py
@@ -1,0 +1,90 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime
+
+import pandas as pd
+
+from enhanced_collector import PostData, PublicationData, SubstackDataCollector
+
+
+class ExportToCsvTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        self.collector_one = SubstackDataCollector("publication-one", self.db_path)
+        self.collector_two = SubstackDataCollector("publication-two", self.db_path)
+
+        self.post_one = self._create_post("post-one", self.collector_one.base_url)
+        self.post_two = self._create_post("post-two", self.collector_two.base_url)
+
+        self.pub_one = self._create_publication("Publication One", self.collector_one.base_url)
+        self.pub_two = self._create_publication("Publication Two", self.collector_two.base_url)
+
+        self.collector_one.save_to_database([self.post_one], self.pub_one)
+        self.collector_two.save_to_database([self.post_two], self.pub_two)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _create_post(self, slug: str, base_url: str) -> PostData:
+        now = datetime.utcnow()
+        return PostData(
+            title=f"Title {slug}",
+            slug=slug,
+            url=f"{base_url}/p/{slug}",
+            content="content",
+            excerpt="excerpt",
+            author="Author",
+            published_at=now,
+            updated_at=now,
+            word_count=100,
+            read_time=5,
+            likes=0,
+            comments=0,
+            shares=0,
+            tags=["tag1", "tag2"],
+            is_premium=False,
+            subscriber_only=False,
+        )
+
+    def _create_publication(self, name: str, base_url: str) -> PublicationData:
+        return PublicationData(
+            name=name,
+            description="desc",
+            url=base_url,
+            subscriber_count=100,
+            posts_count=0,
+            founded_date=datetime.utcnow(),
+            author="Author",
+            social_links={},
+            revenue_estimate=None,
+        )
+
+    def test_export_filters_to_single_publication(self):
+        export_prefix = os.path.join(self.temp_dir.name, "publication_one_export")
+        self.collector_one.export_to_csv(export_prefix)
+
+        posts_df = pd.read_csv(f"{export_prefix}_posts.csv")
+        self.assertFalse(posts_df.empty)
+        self.assertTrue(posts_df["url"].str.startswith(self.collector_one.base_url).all())
+        self.assertEqual(
+            int((posts_df["url"].str.contains("publication-two")).sum()),
+            0,
+        )
+
+        publication_df = pd.read_csv(f"{export_prefix}_publication.csv")
+        self.assertEqual(len(publication_df), 1)
+        self.assertEqual(publication_df.loc[0, "name"], "Publication One")
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM posts").fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- filter CSV post export by publication URL prefix and limit publication export to the resolved publication name
- fall back to URL-based filtering if the publication name lookup fails
- add regression test ensuring only the selected publication's rows are exported when multiple publications share a database

## Testing
- python -m unittest tests.test_export_to_csv

------
https://chatgpt.com/codex/tasks/task_e_68de9629da08832ba2fb0f0a93c3b901